### PR TITLE
fix string res id gen

### DIFF
--- a/buildTools/ACDDResourceGen/src/io/github/bunnyblue/acdd/resources/ResRoot.java
+++ b/buildTools/ACDDResourceGen/src/io/github/bunnyblue/acdd/resources/ResRoot.java
@@ -197,7 +197,7 @@ public class ResRoot {
                 xml.add(node);
                 break;
             case "string":
-                anim.add(node);
+                string.add(node);
                 break;
             case "style":
                 style.add(node);


### PR DESCRIPTION
修正string共享资源id生成错误，现在的resgen的工具的使用在demo中并没有体现